### PR TITLE
Set switch base to prevent compiler downgrades

### DIFF
--- a/lib/op.ml
+++ b/lib/op.ml
@@ -11,7 +11,8 @@ let create runner github_client source switch_name ~configure_command =
   let open Let_syntax.Result in
   (let* () = Opam.create runner ~name:switch_name ~description in
    let* url = Source.switch_target source github_client in
-   Opam.pin_add runner ~name:switch_name url ~configure_command)
+   let* () = Opam.pin_add runner ~name:switch_name url ~configure_command in
+   Opam.set_base runner ~name:switch_name)
   |> reword_error (fun `Unknown -> msgf "Cannot create switch")
 
 type reinstall_mode = Quick | Full

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -58,6 +58,9 @@ let pin_add runner ~name url ~configure_command =
   let cmd = cmd_base @ cmd_rest in
   run_opam runner cmd
 
+let set_base runner ~name =
+  run_opam runner [ A "switch"; A "set-base"; switch name; ocaml_variants ]
+
 let update runner ~name =
   run_opam runner [ A "update"; switch name; ocaml_variants ]
 

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -11,6 +11,8 @@ val pin_add :
   configure_command:Bos.Cmd.t option ->
   (unit, [ `Unknown ]) result
 
+val set_base : Runner.t -> name:Switch_name.t -> (unit, [ `Unknown ]) result
+
 val update : Runner.t -> name:Switch_name.t -> (unit, [ `Unknown ]) result
 
 val reinstall_compiler :

--- a/test/cram/create.t
+++ b/test/cram/create.t
@@ -3,21 +3,25 @@ By default, the switch name is inferred from the branch:
   $ opam-compiler create --dry-run USER/REPO:BRANCH
   Run: OPAMCLI=2.0 opam switch create USER-REPO-BRANCH --empty --description "[opam-compiler] USER/REPO:BRANCH"
   Run: OPAMCLI=2.0 opam pin add --switch USER-REPO-BRANCH --yes ocaml-variants git+https://github.com/USER/REPO#BRANCH
+  Run: OPAMCLI=2.0 opam switch set-base --switch USER-REPO-BRANCH ocaml-variants
 
 It can also be set explicitly:
 
   $ opam-compiler create --dry-run USER/REPO:BRANCH --switch SWITCH-NAME
   Run: OPAMCLI=2.0 opam switch create SWITCH-NAME --empty --description "[opam-compiler] USER/REPO:BRANCH"
   Run: OPAMCLI=2.0 opam pin add --switch SWITCH-NAME --yes ocaml-variants git+https://github.com/USER/REPO#BRANCH
+  Run: OPAMCLI=2.0 opam switch set-base --switch SWITCH-NAME ocaml-variants
 
 Github PR numbers are also accepted:
 
   $ opam-compiler create --dry-run '#1234'
   Run: OPAMCLI=2.0 opam switch create ocaml-ocaml-1234 --empty --description "[opam-compiler] ocaml/ocaml#1234 - Title of ocaml-ocaml-1234"
   Run: OPAMCLI=2.0 opam pin add --switch ocaml-ocaml-1234 --yes ocaml-variants git+https://github.com/user-ocaml-ocaml-1234/repo-ocaml-ocaml-1234#branch-ocaml-ocaml-1234
+  Run: OPAMCLI=2.0 opam switch set-base --switch ocaml-ocaml-1234 ocaml-variants
 
 An explicit configure step can be passed:
 
   $ opam-compiler create --dry-run USER/REPO:BRANCH --configure-command "./configure --enable-x"
   Run: OPAMCLI=2.0 opam switch create USER-REPO-BRANCH --empty --description "[opam-compiler] USER/REPO:BRANCH"
   Run: OPAMEDITOR=sed -i -e 's#"./configure"#"./configure" "--enable-x"#g' OPAMCLI=2.0 opam pin add --switch USER-REPO-BRANCH --yes ocaml-variants git+https://github.com/USER/REPO#BRANCH --edit
+  Run: OPAMCLI=2.0 opam switch set-base --switch USER-REPO-BRANCH ocaml-variants


### PR DESCRIPTION
This adds a call to set-base to lock it.

Closes #7