### PR TITLE
Add create --with=features

### DIFF
--- a/doc/create.txt
+++ b/doc/create.txt
@@ -40,3 +40,8 @@ OPTIONS
            the source. This name is used as is by opam, so passing "." will
            create a local switch in the current directory.
 
+       --with=FEATURES
+           Create a switch with this set of features. For example --with
+           flambda,nnp will create a switch with the flambda and
+           no-naked-pointers features enabled.
+

--- a/dune-project
+++ b/dune-project
@@ -27,6 +27,7 @@
   cmdliner
   curly
   github
+  ocaml-version
   re
   (alcotest
    (and

--- a/lib/dune
+++ b/lib/dune
@@ -1,3 +1,3 @@
 (library
  (name opam_compiler)
- (libraries bos cmdliner curly github re))
+ (libraries bos cmdliner curly github ocaml-version re))

--- a/opam-compiler.opam
+++ b/opam-compiler.opam
@@ -15,6 +15,7 @@ depends: [
   "cmdliner"
   "curly"
   "github"
+  "ocaml-version"
   "re"
   "alcotest" {>= "1.2.0" & with-test}
   "odoc" {with-doc}

--- a/test/cram/create.t
+++ b/test/cram/create.t
@@ -25,3 +25,32 @@ An explicit configure step can be passed:
   Run: OPAMCLI=2.0 opam switch create USER-REPO-BRANCH --empty --description "[opam-compiler] USER/REPO:BRANCH"
   Run: OPAMEDITOR=sed -i -e 's#"./configure"#"./configure" "--enable-x"#g' OPAMCLI=2.0 opam pin add --switch USER-REPO-BRANCH --yes ocaml-variants git+https://github.com/USER/REPO#BRANCH --edit
   Run: OPAMCLI=2.0 opam switch set-base --switch USER-REPO-BRANCH ocaml-variants
+
+Known variants can be supported using --with:
+
+  $ opam-compiler create --dry-run USER/REPO:BRANCH --with afl
+  Run: OPAMCLI=2.0 opam switch create USER-REPO-BRANCH --empty --description "[opam-compiler] USER/REPO:BRANCH"
+  Run: OPAMEDITOR=sed -i -e 's#"./configure"#"./configure" "--with-afl"#g' OPAMCLI=2.0 opam pin add --switch USER-REPO-BRANCH --yes ocaml-variants git+https://github.com/USER/REPO#BRANCH --edit
+  Run: OPAMCLI=2.0 opam switch set-base --switch USER-REPO-BRANCH ocaml-variants
+
+Several of them can be specified:
+
+  $ opam-compiler create --dry-run USER/REPO:BRANCH --with flambda,nnp
+  Run: OPAMCLI=2.0 opam switch create USER-REPO-BRANCH --empty --description "[opam-compiler] USER/REPO:BRANCH"
+  Run: OPAMEDITOR=sed -i -e 's#"./configure"#"./configure" "--enable-flambda" "--disable-naked-pointers"#g' OPAMCLI=2.0 opam pin add --switch USER-REPO-BRANCH --yes ocaml-variants git+https://github.com/USER/REPO#BRANCH --edit
+  Run: OPAMCLI=2.0 opam switch set-base --switch USER-REPO-BRANCH ocaml-variants
+
+A proper error message is displayed if a variant is not recognized:
+
+  $ opam-compiler create --dry-run USER/REPO:BRANCH --with something
+  opam-compiler: option `--with': invalid element in list (`something'):
+                 Unknown variant.
+  Usage: opam-compiler create [OPTION]... SOURCE
+  Try `opam-compiler create --help' or `opam-compiler --help' for more information.
+  [124]
+
+It is not possible to mix --configure-command and --with:
+
+  $ opam-compiler create --dry-run USER/REPO:BRANCH --configure-command "./configure --enable-x" --with afl
+  opam-compiler: --configure-command and --with cannot be passed together.
+  [1]


### PR DESCRIPTION
This is a shorthand for `--configure-command` for "well known" features such as AFL, flambda, etc. This is based on `ocaml-version` so the names are the same as the ones used by opam.