### PR TITLE
Cache github client results

### DIFF
--- a/lib/github_client.mli
+++ b/lib/github_client.mli
@@ -7,3 +7,5 @@ val pr_info : t -> Pull_request.t -> (pr_info, [> `Unknown ]) result
 val real : t
 
 val dry_run : t
+
+val cached : t -> t

--- a/test/unit/test.ml
+++ b/test/unit/test.ml
@@ -1,3 +1,3 @@
-let all_tests = Test_op.tests @ Test_source.tests
+let all_tests = Test_op.tests @ Test_source.tests @ Test_github_client.tests
 
 let () = Alcotest.run "opam-compiler" all_tests

--- a/test/unit/test_github_client.ml
+++ b/test/unit/test_github_client.ml
@@ -1,0 +1,46 @@
+open Opam_compiler
+
+let cache_tests =
+  let pr = { Pull_request.user = "USER"; repo = "REPO"; number = 1 } in
+  let pr_info =
+    {
+      Github_client.title = "TITLE";
+      source_branch =
+        { user = "PR_USER"; repo = "PR_REPO"; branch = "PR_BRANCH" };
+    }
+  in
+  let test name make_client ~expectations =
+    ( name,
+      `Quick,
+      fun () ->
+        let pr_info, check =
+          Mock.create (module Pull_request) __LOC__ expectations
+        in
+        let mock_client = { Github_client.pr_info } in
+        let client = make_client mock_client in
+        for _ = 1 to 3 do
+          let _ = Github_client.pr_info client pr in
+          ()
+        done;
+        check () )
+  in
+  [
+    test "cache is not used"
+      (fun client -> client)
+      ~expectations:
+        [
+          Mock.expect pr ~and_return:(Ok pr_info);
+          Mock.expect pr ~and_return:(Ok pr_info);
+          Mock.expect pr ~and_return:(Ok pr_info);
+        ];
+    test "cache is used" Github_client.cached
+      ~expectations:[ Mock.expect pr ~and_return:(Ok pr_info) ];
+    test "only success is cached" Github_client.cached
+      ~expectations:
+        [
+          Mock.expect pr ~and_return:(Error `Unknown);
+          Mock.expect pr ~and_return:(Ok pr_info);
+        ];
+  ]
+
+let tests = [ ("Cache", cache_tests) ]

--- a/test/unit/test_github_client.mli
+++ b/test/unit/test_github_client.mli
@@ -1,0 +1,1 @@
+val tests : unit Alcotest.test list


### PR DESCRIPTION
The create operation fetches both the source branch and the title when
passed a PR number. By default this does 2 identical HTTP requests. This
adds a cache around this. It holds for the whole duration of the
process.
