### PR TITLE
GitHub urls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Support Github URLs as sources (#32, @emillon)
+
 ## 0.2.0 (2024-01-19)
 
 - Use curl to download (#10, @emillon)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ example, the following is recognized:
     # Use this branch
     opam compiler create 'myself/ocaml:mybranch'
 
+    # Use this pull request
+    opam compiler create https://github.com/ocaml/ocaml/pull/10831
+
 It will try determine a switch name and description from the source name, but it
 is also possible to pass an explicit switch name:
 

--- a/dune-project
+++ b/dune-project
@@ -42,6 +42,7 @@
   (alcotest
    (and
     (>= 1.2.0)
+   uri
     :with-test)))
  (conflicts
   (result (< 1.5))))

--- a/dune-project
+++ b/dune-project
@@ -39,10 +39,10 @@
   re
   (rresult
    (>= 0.6.0))
+  uri
   (alcotest
    (and
     (>= 1.2.0)
-   uri
     :with-test)))
  (conflicts
   (result (< 1.5))))

--- a/lib/dune
+++ b/lib/dune
@@ -1,3 +1,3 @@
 (library
  (name opam_compiler)
- (libraries bos cmdliner curly github-data ocaml-version re))
+ (libraries bos cmdliner curly github-data ocaml-version re uri))

--- a/lib/source.ml
+++ b/lib/source.ml
@@ -72,18 +72,14 @@ let parse_as_branch s =
 
 let parse_as_pr s = Option.map github_pr (Pull_request.parse s)
 
+let ( let/ ) x f = match x with Some r -> Ok r | None -> f ()
+
 let parse s =
-  match parse_as_branch_url s with
-  | Some r -> Ok r
-  | None -> (
-      match parse_as_pr_url s with
-      | Some r -> Ok r
-      | None -> (
-          match parse_as_branch s with
-          | Some r -> Ok r
-          | None -> (
-              match parse_as_pr s with Some r -> Ok r | None -> Error `Unknown))
-      )
+  let/ () = parse_as_branch_url s in
+  let/ () = parse_as_pr_url s in
+  let/ () = parse_as_branch s in
+  let/ () = parse_as_pr s in
+  Error `Unknown
 
 let pp ppf = function
   | Github_branch branch ->

--- a/lib/source.ml
+++ b/lib/source.ml
@@ -44,7 +44,7 @@ let parse_as_branch_url s =
          ])
   in
   let open Let_syntax.Option in
-  let+ g = Re.exec_opt re s in
+  let+ g = Re.exec_opt re (Uri.pct_decode s) in
   let user = Re.Group.get g 1 in
   let repo = Re.Group.get g 2 in
   let branch = Re.Group.get g 3 in

--- a/lib/source.ml
+++ b/lib/source.ml
@@ -26,8 +26,31 @@ let parse_as_pr_url s =
   let number = Re.Group.get g 3 |> int_of_string in
   Github_PR { user; repo; number }
 
+let branch_name = Re.rep1 Re.any
+
+let parse_as_branch_url s =
+  let re =
+    Re.compile
+      (Re.seq
+         [
+           Re.bos;
+           Re.str "https://github.com/";
+           Re.group Pull_request.user_re;
+           Re.str "/";
+           Re.group Pull_request.repo_re;
+           Re.str "/tree/";
+           Re.group branch_name;
+           Re.eos;
+         ])
+  in
+  let open Let_syntax.Option in
+  let+ g = Re.exec_opt re s in
+  let user = Re.Group.get g 1 in
+  let repo = Re.Group.get g 2 in
+  let branch = Re.Group.get g 3 in
+  Github_branch { user; repo; branch }
+
 let parse_as_branch s =
-  let branch_name = Re.rep1 Re.any in
   let re_branch =
     Re.compile
       (Re.seq
@@ -50,13 +73,17 @@ let parse_as_branch s =
 let parse_as_pr s = Option.map github_pr (Pull_request.parse s)
 
 let parse s =
-  match parse_as_pr_url s with
+  match parse_as_branch_url s with
   | Some r -> Ok r
   | None -> (
-      match parse_as_branch s with
+      match parse_as_pr_url s with
       | Some r -> Ok r
       | None -> (
-          match parse_as_pr s with Some r -> Ok r | None -> Error `Unknown))
+          match parse_as_branch s with
+          | Some r -> Ok r
+          | None -> (
+              match parse_as_pr s with Some r -> Ok r | None -> Error `Unknown))
+      )
 
 let pp ppf = function
   | Github_branch branch ->

--- a/opam-compiler.opam
+++ b/opam-compiler.opam
@@ -21,6 +21,7 @@ depends: [
   "re"
   "rresult" {>= "0.6.0"}
   "alcotest" {>= "1.2.0" & with-test}
+  "uri"
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/opam-compiler.opam
+++ b/opam-compiler.opam
@@ -20,8 +20,8 @@ depends: [
   "ocaml-version" {>= "3.0.0"}
   "re"
   "rresult" {>= "0.6.0"}
-  "alcotest" {>= "1.2.0" & with-test}
   "uri"
+  "alcotest" {>= "1.2.0" & with-test}
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/test/unit/test_source.ml
+++ b/test/unit/test_source.ml
@@ -35,6 +35,10 @@ let parse_tests =
          (Github_PR { user = "user"; repo = "repo-with-dashes"; number = 1234 }));
     test "url syntax for issues" "https://github.com/user/repo/pull/1234"
       (Ok (Github_PR { user = "user"; repo = "repo"; number = 1234 }));
+    test "url syntax for branches"
+      "https://github.com/user/repo/tree/branch_name"
+      (Ok
+         (Github_branch { user = "user"; repo = "repo"; branch = "branch_name" }));
   ]
 
 let switch_target_tests =

--- a/test/unit/test_source.ml
+++ b/test/unit/test_source.ml
@@ -33,6 +33,8 @@ let parse_tests =
     test "repos can have dashes" "user/repo-with-dashes#1234"
       (Ok
          (Github_PR { user = "user"; repo = "repo-with-dashes"; number = 1234 }));
+    test "url syntax for issues" "https://github.com/user/repo/pull/1234"
+      (Ok (Github_PR { user = "user"; repo = "repo"; number = 1234 }));
   ]
 
 let switch_target_tests =

--- a/test/unit/test_source.ml
+++ b/test/unit/test_source.ml
@@ -39,6 +39,15 @@ let parse_tests =
       "https://github.com/user/repo/tree/branch_name"
       (Ok
          (Github_branch { user = "user"; repo = "repo"; branch = "branch_name" }));
+    test "urls need to be decoded"
+      "https://github.com/user/repo/tree/4.12.0+domains%2Bsafepoint%2Bchannel_hooks"
+      (Ok
+         (Github_branch
+            {
+              user = "user";
+              repo = "repo";
+              branch = "4.12.0+domains+safepoint+channel_hooks";
+            }));
   ]
 
 let switch_target_tests =


### PR DESCRIPTION
@emillon this is just a rebased version of https://github.com/ocaml-opam/opam-compiler/pull/32 with an example added for how to use the new GitHub urls.

I also want to add support for specific git commit versions like "https://github.com/tmcgilchrist/ocaml/archive/f6058d82bbbe26617dde7d7cffb51c47d4cf2877.zip"